### PR TITLE
getExAC_MAF not behaving like expected

### DIFF
--- a/charger/charger.py
+++ b/charger/charger.py
@@ -460,7 +460,7 @@ class charger(object):
 	def getExAC_MAF( self , values , var ):
 		#if the .vcf does not have AF
 		#then check for ExAC_MAF
-		if ( var.alleleFrequency is not None ):
+		if ( var.alleleFrequency is None ):
 			emaf = self.getVCFKeyIndex( values , "ExAC_MAF" )
 			if emaf is not None:
 				for alt in emaf.split( "&" ):
@@ -472,7 +472,7 @@ class charger(object):
 		return False
 
 	def getGMAF( self , values , var ):
-		if ( var.alleleFrequency is not None ):
+		if ( var.alleleFrequency is None ):
 			gmaf = self.getVCFKeyIndex( values , "GMAF" )
 			if gmaf is not None:
 				for alt in gmaf.split( "&" ):


### PR DESCRIPTION
According to the comments I would expect that if the vcf file does not have a AF field, and thus alleleFrequency is None that the alleleFrequency would be set by the AF from ExAC of 1KG.