### PR TITLE
Fix HGVSc parsing from VEP annotation

### DIFF
--- a/charger/charger.py
+++ b/charger/charger.py
@@ -336,7 +336,7 @@ class charger(object):
 				values = thisCSQ.split( "|" )
 				aas = self.getRefAltAminoAcids( values , var , preVEP )
 				positionPeptide = self.getCodingPosition( values , var , preVEP , "Protein_position" )
-				positionCodon = self.getCodingPosition( values , var , preVEP , "cDNA_position" )
+				positionCodon = self.getCodingPosition( values , var , preVEP , "CDS_position" )
 				exons = self.getExons( values )
 				introns = self.getIntrons( values )
 				siftStuff = self.getSIFT( values )


### PR DESCRIPTION
CharGer was previously pulling cDNA_position field from VEP annotation, instead of CDS_position, which was causing HGVSc annotation in output to be incorrect. This commit fixes that.