### PR TITLE
V.0.5.3

### DIFF
--- a/bin/charger
+++ b/bin/charger
@@ -1,10 +1,11 @@
 #!/usr/bin/env python
 # CharGer - Characterization of Germline variants
-# author: Adam D Scott (adamscott@wustl.edu)
-# author: Kuan-lin Huang (kuan-lin.huang@wustl.edu)
-# author: Amila Weerasinghe (amila@wustl.edu)
-# author: R Jay Mashl (rmashl@wustl.edu)
-# version: v0.5.2 - 2018*01
+# author: 
+#	- Adam D Scott (ascott@genome.wustl.edu)
+#	- Fernanda Martins Rodrigues (fernanda@wustl.edu)
+#	- Jay R. Mashl (rmashl@wustl.edu)
+#	- Kuan-lin Huang (khuang@genome.wustl.edu)
+# version: v0.5.3 - September, 2019
 
 import sys
 import getopt
@@ -13,7 +14,7 @@ import time
 import argparse
 
 def parseArgs( argv ):
-	helpText = "\nCharGer - v0.5.2\n\n"
+	helpText = "\nCharGer - v0.5.3\n\n"
 	helpText += "Usage: "
 	helpText += "charger <input file> [options]\n\n"
 	helpText += "Accepted input data files:\n"

--- a/charger/autovivification.py
+++ b/charger/autovivification.py
@@ -1,7 +1,12 @@
 #!/usr/bin/env python
 # autovivification - extends dict
-# author: Kuan-lin Huang (khuang@genome.wustl.edu) & Adam D Scott (ascott@genome.wustl.edu)
-# version: v0.0 - 2016*01*12
+# CharGer - Characterization of Germline variants
+# author: 
+#	- Adam D Scott (ascott@genome.wustl.edu)
+#	- Fernanda Martins Rodrigues (fernanda@wustl.edu)
+#	- Jay R. Mashl (rmashl@wustl.edu)
+#	- Kuan-lin Huang (khuang@genome.wustl.edu)
+# version: v0.5.3 - September, 2019
 
 class autovivification(dict):
 	'''Implementation of perl's autovivification feature.'''

--- a/charger/chargervariant.py
+++ b/charger/chargervariant.py
@@ -1,7 +1,11 @@
 #!/usr/bin/env python
-# chargervariant - CharGer annotated variants
-# author: Adam D Scott (ascott@genome.wustl.edu) & Kuan-lin Huang (khuang@genome.wustl.edu)
-# version: v0.0 - 2016*01*13
+# CharGer - Characterization of Germline variants
+# author: 
+#	- Adam D Scott (ascott@genome.wustl.edu)
+#	- Fernanda Martins Rodrigues (fernanda@wustl.edu)
+#	- Jay R. Mashl (rmashl@wustl.edu)
+#	- Kuan-lin Huang (khuang@genome.wustl.edu)
+# version: v0.5.3 - September, 2019
 
 import pdb
 from biomine.variant.clinvarvariant import clinvarvariant

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 #https://docs.python.org/2/distutils/examples.html
 from distutils.core import setup
-version = "0.5.2"
+version = "0.5.3"
 setup( \
 	name = 'CharGer' , 
 	version = version , 


### PR DESCRIPTION
Bug fixes in parsing of ClinVar information

Changes include:
- Fixed parseMacPathogenicity() to handle variants with multiple submitters that received both benign and pathogenic classifications, but no conflict is reported (i.e. `isPathogenic == 1 and isBenign == 1 and isConflicted == 0`)

- Fixed bug reported in pull request #19:  var.splitHGVSc, which doesn't consider strand information. When override = True, the ref and alt for genomic variants would be wrongly changed for minus strand transcripts. Changed to override = False

- Fixed bug reported in pull request #19: fixed corrdinates in getMacClinVarTSV() to match readVCF().